### PR TITLE
Use new parameter name for sending post

### DIFF
--- a/jsapi/jsapi_for_google_plus.js
+++ b/jsapi/jsapi_for_google_plus.js
@@ -1468,7 +1468,7 @@ GooglePlusAPI.prototype.newPost = function(callback, postObj) {
   data[29] = false;
   data[36] = [];
 
-  var params = 'spar=' + encodeURIComponent(JSON.stringify(data)) +
+  var params = 'f.req=' + encodeURIComponent(JSON.stringify(data)) +
       '&at=' + encodeURIComponent(this._getSession());
 
   this._requestService(function(response) {


### PR DESCRIPTION
Not a breaking change yet, but best to keep up with the native Google+ client
